### PR TITLE
Renamed 020-BlueSpiceFree.php and added 020-BlueSpiceTagCloud.php

### DIFF
--- a/settings.d/010-BlueSpiceFree.php
+++ b/settings.d/010-BlueSpiceFree.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once __DIR__ . "/../extensions/BlueSpiceFoundation/BlueSpiceFoundation.php";
+require_once __DIR__ . "/../skins/BlueSpiceSkin/BlueSpiceSkin.php";

--- a/settings.d/020-BlueSpiceFree.php
+++ b/settings.d/020-BlueSpiceFree.php
@@ -1,5 +1,0 @@
-<?php
-
-require_once __DIR__ . "/../extensions/BlueSpiceFoundation/BlueSpiceFoundation.php";
-require_once __DIR__ . "/../extensions/BlueSpiceTagCloud/BlueSpiceTagCloud.php";
-require_once __DIR__ . "/../skins/BlueSpiceSkin/BlueSpiceSkin.php";

--- a/settings.d/020-BlueSpiceTagCloud.php
+++ b/settings.d/020-BlueSpiceTagCloud.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . "/../extensions/BlueSpiceTagCloud/BlueSpiceTagCloud.php";


### PR DESCRIPTION
The BlueSpiceFoundation should be loaded before any other BlueSpice-Extension (020-*).
Also the TagCloud is an own extension (now 020-BlueSpiceTagCloud.php