### PR TITLE
Remove Extension:Lockdown

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -15,7 +15,6 @@
 		"mediawiki/hit-counters": "dev-REL1_31",
 		"mediawiki/image-map-edit": "dev-REL1_31",
 		"mediawiki/lingo": "~3.0",
-		"mediawiki/lockdown": "dev-REL1_31",
 		"mediawiki/nuke": "dev-REL1_31",
 		"mediawiki/pluggable-auth": "dev-master",
 		"mediawiki/quiz": "dev-REL1_31",

--- a/settings.d/001-BlueSpiceDistribution.php
+++ b/settings.d/001-BlueSpiceDistribution.php
@@ -5,7 +5,6 @@ require_once __DIR__ . "/../extensions/CategoryTree/CategoryTree.php";
 wfLoadExtension( 'DynamicPageList' );
 require_once __DIR__ . "/../extensions/HitCounters/HitCounters.php";
 require_once __DIR__ . "/../extensions/ImageMapEdit/ImageMapEdit.php";
-wfLoadExtension( 'Lockdown' );
 require_once __DIR__ . "/../extensions/Quiz/Quiz.php";
 wfLoadExtension( 'RSS' );
 wfLoadExtension( 'Echo');


### PR DESCRIPTION
This extension is not part of BlueSpice Distribution anymore

ERM10745

NEEDS CHERRY-PICK TO master