### PR TITLE
Fix git submodule init error when building with composer

### DIFF
--- a/_bluespice/pre-autoload-dump.d/load_git_submodules.sh
+++ b/_bluespice/pre-autoload-dump.d/load_git_submodules.sh
@@ -6,5 +6,7 @@
 # Copyright: 2017
 # License: GPLv3
 
+mv vendor vendor_by_composer
 git submodule update --init --recursive
-
+rm -rf vendor
+mv vendor_by_composer vendor


### PR DESCRIPTION
This is just a workaround. The problem is, that the script

    _bluespice/pre-autoload-dump.d/load_git_submodules.sh

is executed during the "pre-autoload-dump" event of the composer installer.
At this point a `vendor` directory has already been created by composer. This
leads to an error in `git submodules init`. As a result the submodule repos
are not checked out properly.

There are thwo other options to handle this:

1) Remove the vendor submodule from this repo. This may lead to issues when
merging from upstream, as the submodule state may change

2) Use composer's "pre-install" command. This can only be done by modifing
`composer.json` and either enable "merge-scripts" of the merge plugin [1]
or modify the value of "pre-install" directly. The second way is more likely
to produce errors when merging from upstream

[1] https://gerrit.wikimedia.org/r/#/c/mediawiki/core/+/424263/

NEEDS CHERRY-PICK TO REL1_27! Should probably also be cherry-picked to master,
even though there are not submodules in core.