### PR TITLE
Update 020-VisualEditor.php

### DIFF
--- a/settings.d/020-VisualEditor.php
+++ b/settings.d/020-VisualEditor.php
@@ -36,8 +36,7 @@ $wgVirtualRestConfig['modules']['parsoid'] = array(
 	// URL to the Parsoid instance
 	// Use port 8142 if you use the Debian package
 	'url' => 'http://localhost:8000',
-	'domain' => 'localhost',
-	'prefix' => 'localhost',
+	'domain' => 'bluespice',
 	'forwardCookies' => true
 );
 


### PR DESCRIPTION
- In documentation we will use "bluespice" as value for domain.
- Prefix not needed