### PR TITLE
Remove old TimeZone Setting

### DIFF
--- a/settings.d/005-DefaultSettings.php
+++ b/settings.d/005-DefaultSettings.php
@@ -2,7 +2,6 @@
 
 $wgLocalTZoffset = date("Z") / 60;
 $wgLocaltimezone = 'Europe/Berlin';
-$wgDefaultUserOptions['timecorrection'] = 'ZoneInfo|' . (date("I") ? 120 : 60) . '|Europe/Berlin';
 $wgUrlProtocols[] = 'file://';
 $wgNamespacesWithSubpages[NS_MAIN] = true;
 $wgExternalLinkTarget = '_blank';


### PR DESCRIPTION
The old settign $wgDefaultUserOptions['timecorrection'] was only used for very old MW Versions and is not needed any more, see: https://www.mediawiki.org/wiki/Manual:Timezone

Found while investigating ERM#14919