### PR TITLE
Conditionally set cache directory (REL1_31)

### DIFF
--- a/settings.d/005-Directories.php
+++ b/settings.d/005-Directories.php
@@ -3,7 +3,9 @@
 // Cache directory.
 // If this is not set database will be used.
 // Must be writable by webserver.
-$wgCacheDirectory = __DIR__ . "/../cache";
+if( !$wgCacheDirectory ) {
+	$wgCacheDirectory = __DIR__ . "/../cache";
+}
 
 // This often causes problems. Only if really needed.
 // Must be writable by webserver.


### PR DESCRIPTION
Setting the `$wgCacheDirectory` at this point causes trouble in some setups.
E.g. in a BlueSpiceWikiFarm-Setup, it will overwrite the pre-set
instance-dependant value, causing all instances to use the same cache
directory.

ERM15551 et al.

NEEDS CHERRY-PICK TO `master` AND `REL1_31_dev`!