### PR TITLE
Add `Monolog` to production-builds

### DIFF
--- a/_bluespice/build/bluespice-free/composer.json
+++ b/_bluespice/build/bluespice-free/composer.json
@@ -4,6 +4,8 @@
 		"url": "https://packages.bluespice.com/"
 	}],
 	"require": {
+		"monolog/monolog": "~1.22.1",
+
 		"bluespice/foundation": "dev-REL1_31",
 		"bluespice/about": "dev-REL1_31",
 		"bluespice/articleinfo": "dev-REL1_31",


### PR DESCRIPTION
When a package is build with the `composer update --no-dev` command the
`monolog/monolog` package will not be included. But for advanced
debugging it is very important to have this in a customer setup.

ATTENTION: This should be kept in snyc with the package requirement in
`<mediawiki>/composer.json/require-dev`

[3.1.x]