### PR TITLE
Remove VisualEditor from build files

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -25,7 +25,6 @@
 		"mediawiki/user-functions": "dev-REL1_35",
 		"mediawiki/user-merge": "dev-REL1_35",
 		"mediawiki/variables": "dev-REL1_35",
-		"mediawiki/visual-editor": "dev-REL1_35",
 		"mediawiki/url-get-parameters": "dev-REL1_35"
 	}
 }


### PR DESCRIPTION
This extension is now part of the official MediaWiki release and will be
included in the codebase anyways.

ERM#21028

[3.3]