### PR TITLE
Remove Quiz extension from distribution

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -17,7 +17,6 @@
 		"mediawiki/lingo": "~3.0",
 		"mediawiki/nuke": "dev-master",
 		"mediawiki/pluggable-auth": "dev-master",
-		"mediawiki/quiz": "dev-master",
 		"mediawiki/rss": "dev-master",
 		"mediawiki/simple-s-a-m-lphp": "dev-master",
 		"mediawiki/template-styles": "dev-master",

--- a/settings.d/001-BlueSpiceDistribution.php
+++ b/settings.d/001-BlueSpiceDistribution.php
@@ -5,7 +5,6 @@ wfLoadExtension( 'CategoryTree' );
 wfLoadExtension( 'DynamicPageList' );
 require_once __DIR__ . "/../extensions/HitCounters/HitCounters.php";
 require_once __DIR__ . "/../extensions/ImageMapEdit/ImageMapEdit.php";
-require_once __DIR__ . "/../extensions/Quiz/Quiz.php";
 wfLoadExtension( 'RSS' );
 wfLoadExtension( 'Echo');
 wfLoadExtension( 'TitleKey');


### PR DESCRIPTION
As of RAB decision on 2020-11-09

ERM22163

[4.x]