### PR TITLE
Remove Quiz extension from distribution

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -17,7 +17,6 @@
 		"mediawiki/lingo": "~3.0",
 		"mediawiki/nuke": "dev-REL1_35",
 		"mediawiki/pluggable-auth": "dev-REL1_35",
-		"mediawiki/quiz": "dev-REL1_35",
 		"mediawiki/rss": "dev-REL1_35",
 		"mediawiki/simple-s-a-m-lphp": "dev-REL1_35",
 		"mediawiki/template-styles": "dev-REL1_35",

--- a/settings.d/001-BlueSpiceDistribution.php
+++ b/settings.d/001-BlueSpiceDistribution.php
@@ -5,7 +5,6 @@ wfLoadExtension( 'CategoryTree' );
 wfLoadExtension( 'DynamicPageList' );
 require_once __DIR__ . "/../extensions/HitCounters/HitCounters.php";
 require_once __DIR__ . "/../extensions/ImageMapEdit/ImageMapEdit.php";
-require_once __DIR__ . "/../extensions/Quiz/Quiz.php";
 wfLoadExtension( 'RSS' );
 wfLoadExtension( 'Echo');
 wfLoadExtension( 'TitleKey');


### PR DESCRIPTION
As of RAB decision on 2020-11-09

ERM22163

[4.x]