### PR TITLE
Remove `Extension:CookieWarning`

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -7,7 +7,6 @@
 		"bluespice/visualeditorconnector": "dev-master",
 		"hallowelt/filter-special-pages": "dev-master",
 		"mediawiki/arrays": "dev-master",
-		"mediawiki/cookie-warning": "dev-master",
 		"mediawiki/dynamic-page-list": "dev-master",
 		"mediawiki/echo": "dev-master",
 		"mediawiki/embed-video": "dev-master",

--- a/settings.d/030-CookieWarning.php
+++ b/settings.d/030-CookieWarning.php
@@ -1,3 +1,0 @@
-<?php
-return;
-wfLoadExtension( 'CookieWarning' );


### PR DESCRIPTION
As of RAB decision from 2021-07-26

ERM25431

[4.0.x]