### PR TITLE
Remove `Extension:CookieWarning`

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -7,7 +7,6 @@
 		"bluespice/visualeditorconnector": "dev-REL1_35",
 		"hallowelt/filter-special-pages": "dev-REL1_35",
 		"mediawiki/arrays": "dev-REL1_35",
-		"mediawiki/cookie-warning": "dev-REL1_35",
 		"mediawiki/dynamic-page-list": "3.3.4",
 		"mediawiki/echo": "dev-REL1_35",
 		"mediawiki/embed-video": "2.7.4",

--- a/settings.d/030-CookieWarning.php
+++ b/settings.d/030-CookieWarning.php
@@ -1,3 +1,0 @@
-<?php
-return;
-wfLoadExtension( 'CookieWarning' );


### PR DESCRIPTION
As of RAB decision from 2021-07-26

ERM25431

[4.0.x]