### PR TITLE
Add `Extension:OATHAuth` dependencies

### DIFF
--- a/composer.local.json
+++ b/composer.local.json
@@ -3,7 +3,8 @@
 	"extra": {
 		"merge-plugin": {
 			"include": [
-				"_bluespice/build/*/composer.json"
+				"_bluespice/build/*/composer.json",
+				"extensions/OATHAuth/composer.json"
 			],
 			"merge-extra": true,
 			"merge-scripts": true


### PR DESCRIPTION
[3.2.x]

This is only for a "git-submodule bundeled" extension, therefore not required in `master`!

ERM24220