### PR TITLE
Remove long out of use workaround

### DIFF
--- a/settings.d/020-BlueSpiceWikiAdmin.php
+++ b/settings.d/020-BlueSpiceWikiAdmin.php
@@ -1,7 +1,9 @@
 <?php
+return;
 //wfLoadExtension("BlueSpiceExtensions/WikiAdmin");
 //Workaround from pwirth as of 28.11.2017, this should be removed after module has been defined on another place
-class WikiAdmin {
+// The last usage of this was removed within 2.27.4
+/*class WikiAdmin {
 	static function registerModuleClass() {}
 	static function registerModule() {}
-}
+}*/


### PR DESCRIPTION
Remove long out of use workaround for required class WikiAdmin

ERM:17148
[3.2]