### PR TITLE
Remove long out of use workaround

### DIFF
--- a/settings.d/020-BlueSpiceWikiAdmin.php
+++ b/settings.d/020-BlueSpiceWikiAdmin.php
@@ -1,7 +1,8 @@
 <?php
+return;
 //wfLoadExtension("BlueSpiceExtensions/WikiAdmin");
 //Workaround from pwirth as of 28.11.2017, this should be removed after module has been defined on another place
-class WikiAdmin {
+/*class WikiAdmin {
 	static function registerModuleClass() {}
 	static function registerModule() {}
-}
+}*/


### PR DESCRIPTION
Remove long out of use workaround for required class WikiAdmin

ERM:17148
[3.2]