### PR TITLE
Publish StandardDialogs

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -26,7 +26,7 @@
 		"mediawiki/user-merge": "dev-REL1_35",
 		"mediawiki/variables": "dev-REL1_35",
 		"mediawiki/url-get-parameters": "dev-REL1_35",
-		"mediawiki/standard-dialogs": "dev-master",
+		"mediawiki/standard-dialogs": "dev-REL1_35",
 		"mediawiki/page-header": "dev-master"
 	}
 }


### PR DESCRIPTION
StandardDialogs was now published on gerrit with stable REL1_35

Only merge after pckages.bluespice.com knows about the rew repo!
ERM:26482
[4.x]