### PR TITLE
Bump Extension:Variables version

### DIFF
--- a/_bluespice/build/bluespice-free-distribution/composer.json
+++ b/_bluespice/build/bluespice-free-distribution/composer.json
@@ -22,7 +22,7 @@
 		"mediawiki/two-col-conflict": "dev-REL1_39",
 		"mediawiki/user-functions": "dev-REL1_39",
 		"mediawiki/user-merge": "dev-REL1_39",
-		"mediawiki/variables": "dev-REL1_39",
+		"mediawiki/variables": "2.5.3",
 		"mediawiki/url-get-parameters": "dev-REL1_39",
 		"mediawiki/standard-dialogs": "dev-REL1_39",
 		"mediawiki/page-header": "dev-REL1_39",


### PR DESCRIPTION
Remove use of InternalParseBeforeSanitize hook

ERM28913

[REL1_39, REL1_39-4.3.x, REL1_39-4.4.x]