### PR TITLE
Remove default BlueSpiceRating MetaItemsFooter

### DIFF
--- a/settings.d/080-BlueSpiceDiscovery.php
+++ b/settings.d/080-BlueSpiceDiscovery.php
@@ -10,4 +10,4 @@ $GLOBALS['wgSkipSkins'] = [
 ];
 
 $GLOBALS['bsgDiscoveryMetaItemsHeader'] = [ "page-sentence" ];
-$GLOBALS['bsgDiscoveryMetaItemsFooter'] = [ "categories", "rating", "recommendations" ];
+$GLOBALS['bsgDiscoveryMetaItemsFooter'] = [ "categories" ];


### PR DESCRIPTION
BlueSpiceRating is only in pro version

ERM35596

[REL1_35*, REL1_39*, master]