### PR TITLE
Remove Extension:ExtJS

### DIFF
--- a/_bluespice/build/bluespice-free/composer.json
+++ b/_bluespice/build/bluespice-free/composer.json
@@ -49,7 +49,6 @@
 		"bluespice/usersidebar": "dev-master",
 		"bluespice/watchlist": "dev-master",
 		"bluespice/whoisonline": "dev-master",
-		"mediawiki/extjs-base": "dev-master",
 		"mediawiki/oojsplus": "dev-master",
 
 		"bluespice/discovery-skin": "dev-master"

--- a/settings.d/005-DefaultSettings.php
+++ b/settings.d/005-DefaultSettings.php
@@ -77,8 +77,6 @@ $GLOBALS['bsgDefaultPermissionsPolicyHeader'] = [
 	'picture-in-picture' => '',
 	'publickey-credentials-get' => '',
 	'screen-wake-lock' => '',
-	// Required for ExtJS class loader
-	'sync-xhr' => 'self',
 	'usb' => '',
 	'web-share' => '',
 	'xr-spatial-tracking' => ''

--- a/settings.d/030-ExtJSBase.php
+++ b/settings.d/030-ExtJSBase.php
@@ -1,2 +1,0 @@
-<?php
-wfLoadExtension( 'ExtJSBase' );


### PR DESCRIPTION
With BlueSpice 5.0, we entirely drop ExtJS