### PR TITLE
Load BSF first

### DIFF
--- a/settings.d/015-BlueSpiceFree.php
+++ b/settings.d/015-BlueSpiceFree.php
@@ -1,5 +1,6 @@
 <?php
 
+wfLoadExtension( 'BlueSpiceFoundation' );
 wfLoadExtension( 'BlueSpiceAbout' );
 wfLoadExtension( 'BlueSpiceArticleInfo' );
 wfLoadExtension( 'BlueSpiceAuthors' );
@@ -11,7 +12,6 @@ wfLoadExtension( 'BlueSpiceCountThings' );
 wfLoadExtension( 'BlueSpiceCustomMenu' );
 wfLoadExtension( 'BlueSpiceEmoticons' );
 wfLoadExtension( 'BlueSpiceExtendedStatistics' );
-wfLoadExtension( 'BlueSpiceFoundation' );
 wfLoadExtension( 'BlueSpiceGroupManager' );
 wfLoadExtension( 'BlueSpiceHideTitle' );
 wfLoadExtension( 'BlueSpiceInsertCategory' );


### PR DESCRIPTION
Since attributes are registered on a first-come-first-serve basis, we need to make sure to load BSF first, as many of its attributes are overriden by other extensions