### PR TITLE
Adjust PdfHandler patch

### DIFF
--- a/_bluespice/patches/extensions/PdfHandler/includes/PdfHandler.php.diff
+++ b/_bluespice/patches/extensions/PdfHandler/includes/PdfHandler.php.diff
@@ -1,47 +1,19 @@
 diff --git a/includes/PdfHandler.php b/includes/PdfHandler.php
-index 0ce0faf..26abf2f 100644
+index 86a328d..9ca9179 100644
 --- a/includes/PdfHandler.php
 +++ b/includes/PdfHandler.php
-@@ -224,17 +224,31 @@ class PdfHandler extends ImageHandler {
-			"-q",
-			$srcPath
-		);
--		$cmd .= " | " . wfEscapeShellArg(
--			$wgPdfPostProcessor,
--			"-depth",
--			"8",
--			"-quality",
--			$wgPdfHandlerJpegQuality,
--			"-resize",
--			(string)$width,
--			"-",
--			$dstPath
--		);
-+		if ( wfIsWindows() ) {
-+			$cmd .= " | " . wfEscapeShellArg(
-+				$wgPdfPostProcessor,
-+				"-",
-+				"-depth",
-+				"8",
-+				"-quality",
-+				$wgPdfHandlerJpegQuality,
-+				"-resize",
-+				$width,
-+				$dstPath
-+			);
-+		} else {
-+			$cmd .= " | " . wfEscapeShellArg(
-+				$wgPdfPostProcessor,
-+				"-depth",
-+				"8",
-+				"-quality",
-+				$wgPdfHandlerJpegQuality,
-+				"-resize",
-+				$width,
-+				"-",
-+				$dstPath
-+			);
-+		}
-		$cmd .= ")";
- 
-		wfDebug( __METHOD__ . ": $cmd\n" );
+@@ -226,13 +226,13 @@ class PdfHandler extends ImageHandler {
+				);
+				$cmd .= " | " . wfEscapeShellArg(
+						$wgPdfPostProcessor,
++						"jpeg:-",
+						"-depth",
+						"8",
+						"-quality",
+						$wgPdfHandlerJpegQuality,
+						"-resize",
+						(string)$width,
+-						"-",
+						$dstPath
+				);
+				$cmd .= ")";


### PR DESCRIPTION
I cannot find a proper Windows test environment, though I noticed that putting the target to the front works as well on Linux. 

Specifying type jpeg (the same as the output format of gs)  prevents this error when using `magick` instead of `convert`: magick: no images found for operation `-resize' at CLI arg 5 @ error/operation.c/CLIOption/5481.

This command is yet compatible with `convert`.